### PR TITLE
add style to header title to match logo, add font link to index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,21 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-react-app"
-    />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
+
+<head>
+  <meta charset="utf-8" />
+  <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description" content="Web site created using create-react-app" />
+  <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+  <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -24,12 +22,14 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
+  <link href="https://fonts.googleapis.com/css2?family=Concert+One&display=swap" rel="stylesheet">
+  <title>React App</title>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+  <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
 
@@ -39,5 +39,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-  </body>
+</body>
+
 </html>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,9 +1,23 @@
 import React from "react";
 
 export default function Header() {
+  const styleBooks = {
+    fontFamily: "Concert One",
+    color: "#34AAE6",
+    fontSize: "2rem",
+    fontWeight: 700,
+    padding: 10
+  }
+
+  const stylePlus = {
+    color: "#206DB1"
+  }
+
   return (
     <header>
-      <h1>Books Plus</h1>
+      <div style={styleBooks}>
+        BOOKS<span style={stylePlus}>PLUS</span>
+      </div>
     </header>
   );
 }


### PR DESCRIPTION
Add style to head title to match logo text.
As imported same fonts from font google to display/match same as logo. 
Improve user style experience. As it is text, will maintain aspect ratio without the need to use/insert an image.

![image.png](https://images.zenhubusercontent.com/5f43d4c02b075c6a5d44a553/682541c2-d9c2-4bf8-a789-bfcdca5e3da4)

![image.png](https://images.zenhubusercontent.com/5f43d4c02b075c6a5d44a553/2f4b8169-be7a-4324-90d0-e126ec0d9173)